### PR TITLE
Fixing bugs with MAX32570 QSPI configuartion.

### DIFF
--- a/tcl/target/max32570.cfg
+++ b/tcl/target/max32570.cfg
@@ -51,9 +51,16 @@ if {$QSPI_ENABLE == 1} {
       set PERRST_ADDR  0x40000044
 
       set GPIO1_EN_ADDR  0x40009000
+      set GPIO1_OUT_EN_ADDR  0x4000900C
+      set GPIO1_OUT_SET_ADDR  0x4000901C
       set GPIO1_EN1_ADDR 0x40009068
       set GPIO1_EN2_ADDR 0x40009074
-      set GPIO1_SPI_MASK 0xF03FFFFF
+      set GPIO1_DS0_ADDR 0x400090B0
+      set GPIO1_DS1_ADDR 0x400090B4
+      set GPIO1_VSSEL_ADDR 0x400090C0
+
+      set GPIO1_SPI_MASK 0xF63FFFFF
+      set GPIO1_RST_MASK 0x06000000
 
       # Enable SPI and GPIO1 clocks
       set TEMP [mrw $CLKDIS0_ADDR]
@@ -82,6 +89,30 @@ if {$QSPI_ENABLE == 1} {
       set TEMP [mrw $GPIO1_EN2_ADDR]
       set TEMP_MOD [expr { $TEMP & $GPIO1_SPI_MASK} ]
       mww $GPIO1_EN2_ADDR $TEMP_MOD
+
+      # Set the HOLD/RST and WP lines high
+      set TEMP [mrw $GPIO1_EN_ADDR]
+      set TEMP_MOD [expr { $TEMP | $GPIO1_RST_MASK} ]
+      mww $GPIO1_EN_ADDR $TEMP_MOD
+
+      set TEMP [mrw $GPIO1_OUT_EN_ADDR]
+      set TEMP_MOD [expr { $TEMP | $GPIO1_RST_MASK} ]
+      mww $GPIO1_OUT_EN_ADDR $TEMP_MOD
+      mww $GPIO1_OUT_SET_ADDR $GPIO1_RST_MASK
+
+      # Max drive strength
+      set TEMP [mrw $GPIO1_DS0_ADDR]
+      set TEMP_MOD [expr { $TEMP | $GPIO1_RST_MASK | ~($GPIO1_SPI_MASK) } ]
+      mww $GPIO1_DS0_ADDR $TEMP_MOD
+
+      set TEMP [mrw $GPIO1_DS0_ADDR]
+      set TEMP_MOD [expr { $TEMP | $GPIO1_RST_MASK | ~($GPIO1_SPI_MASK) } ]
+      mww $GPIO1_DS1_ADDR $TEMP_MOD
+      
+      # Use VDDIOH
+      set TEMP [mrw $GPIO1_VSSEL_ADDR]
+      set TEMP_MOD [expr { $TEMP | $GPIO1_RST_MASK | ~($GPIO1_SPI_MASK) } ]
+      mww $GPIO1_VSSEL_ADDR $TEMP_MOD
 
       # Finish setting up the QSPI, 2 is the flash bank id for the qspi driver
       max32xxx_qspi reset_deassert 2


### PR DESCRIPTION
Using VDDIOH (3.3V) for IO voltage.
Maximizing GPIO drive strength.
Driving WP and HOLD/RST high.