### PR TITLE
Add Missing RISC-V Config Files

### DIFF
--- a/tcl/target/max32655_riscv.cfg
+++ b/tcl/target/max32655_riscv.cfg
@@ -28,5 +28,5 @@ flash bank $CHIPNAME.flash max32xxx $FLASH_BASE $FLASH_SIZE 0 0 $CHIPNAME.cpu $F
 
 $CHIPNAME.cpu configure -event reset-end { 
     # Set the PC to the load address where the interrupt vector is stored
-    reg pc 0x10004000
+    reg pc Reset_Handler
 }

--- a/tcl/target/max32655_riscv.cfg
+++ b/tcl/target/max32655_riscv.cfg
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Maxim Integrated MAX32655 OpenOCD target configuration file
 # www.maximintegrated.com
 

--- a/tcl/target/max32680_riscv.cfg
+++ b/tcl/target/max32680_riscv.cfg
@@ -1,0 +1,31 @@
+# MAX32680 RISC-V core OpenOCD configuration
+
+# Set the reset pin configuration
+reset_config srst_only
+
+# set reset delay so ARM core can re-enable RISCV debugger pins
+adapter srst delay 100
+
+adapter speed 4000
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x80000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 100
+set FLASH_OPTIONS 0x01
+
+set CHIPNAME max32xxx_riscv
+
+jtag newtap $CHIPNAME cpu -irlen 4 -irmask 0xf -ircapture 0x5 -expected-id 0x16210197 -ignore-version
+target create $CHIPNAME.cpu rvmax -chain-position $CHIPNAME.cpu
+
+$CHIPNAME.cpu configure -work-area-phys 0x20010000 -work-area-size 0x1000
+
+flash bank $CHIPNAME.flash max32xxx $FLASH_BASE $FLASH_SIZE 0 0 $CHIPNAME.cpu $FLC_BASE $FLASH_SECTOR $FLASH_CLK $FLASH_OPTIONS
+
+$CHIPNAME.cpu configure -event reset-end { 
+    # Set the PC to the load address where the interrupt vector is stored
+    reg pc Reset_Handler
+}

--- a/tcl/target/max32680_riscv.cfg
+++ b/tcl/target/max32680_riscv.cfg
@@ -1,4 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # MAX32680 RISC-V core OpenOCD configuration
+# www.analog.com
 
 # Set the reset pin configuration
 reset_config srst_only
@@ -25,7 +27,7 @@ $CHIPNAME.cpu configure -work-area-phys 0x20010000 -work-area-size 0x1000
 
 flash bank $CHIPNAME.flash max32xxx $FLASH_BASE $FLASH_SIZE 0 0 $CHIPNAME.cpu $FLC_BASE $FLASH_SECTOR $FLASH_CLK $FLASH_OPTIONS
 
-$CHIPNAME.cpu configure -event reset-end { 
+$CHIPNAME.cpu configure -event reset-end {
     # Set the PC to the load address where the interrupt vector is stored
     reg pc Reset_Handler
 }

--- a/tcl/target/max32690_riscv.cfg
+++ b/tcl/target/max32690_riscv.cfg
@@ -1,4 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # MAX32690 RISC-V core OpenOCD configuration
+# www.analog.com
 
 # Set the reset pin configuration
 reset_config srst_only
@@ -33,7 +35,7 @@ target create $CHIPNAME.cpu rvmax -chain-position $CHIPNAME.cpu
 
 $CHIPNAME.cpu configure -work-area-phys 0x20010000 -work-area-size 0x1000
 
-$CHIPNAME.cpu configure -event reset-end { 
+$CHIPNAME.cpu configure -event reset-end {
     # Set the PC to the load address where the interrupt vector is stored
     reg pc Reset_Handler
 }

--- a/tcl/target/max32690_riscv.cfg
+++ b/tcl/target/max32690_riscv.cfg
@@ -1,0 +1,39 @@
+# MAX32690 RISC-V core OpenOCD configuration
+
+# Set the reset pin configuration
+reset_config srst_only
+
+# set reset delay so ARM core can re-enable RISCV debugger pins
+adapter srst delay 100
+
+adapter speed 4000
+
+set CHIPNAME max32xxx_riscv
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x300000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x4000
+set FLASH_CLK 60
+set FLASH_OPTIONS 0x01
+
+flash bank $CHIPNAME.flash max32xxx $FLASH_BASE $FLASH_SIZE 0 0 $CHIPNAME.cpu $FLC_BASE $FLASH_SECTOR $FLASH_CLK $FLASH_OPTIONS
+
+# Add additional flash bank
+set FLASH_BASE 0x10300000
+set FLASH_SIZE 0x40000
+set FLC_BASE 0x40029400
+set FLASH_SECTOR 0x2000
+
+flash bank $CHIPNAME.flash1 max32xxx $FLASH_BASE $FLASH_SIZE 0 0 $_CHIPNAME.cpu $FLC_BASE $FLASH_SECTOR $FLASH_CLK $FLASH_OPTIONS
+
+jtag newtap $CHIPNAME cpu -irlen 4 -irmask 0xf -ircapture 0x5 -expected-id 0x16210197 -ignore-version
+target create $CHIPNAME.cpu rvmax -chain-position $CHIPNAME.cpu
+
+$CHIPNAME.cpu configure -work-area-phys 0x20010000 -work-area-size 0x1000
+
+$CHIPNAME.cpu configure -event reset-end { 
+    # Set the PC to the load address where the interrupt vector is stored
+    reg pc Reset_Handler
+}

--- a/tcl/target/max78000_riscv.cfg
+++ b/tcl/target/max78000_riscv.cfg
@@ -1,0 +1,31 @@
+# MAX78000 RISC-V core OpenOCD configuration
+
+# Set the reset pin configuration
+reset_config srst_only
+
+# set reset delay so ARM core can re-enable RISCV debugger pins
+adapter srst delay 100
+
+adapter speed 4000
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x80000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 100
+set FLASH_OPTIONS 0x01
+
+set CHIPNAME max32xxx_riscv
+
+jtag newtap $CHIPNAME cpu -irlen 4 -irmask 0xf -ircapture 0x5 -expected-id 0x16210197 -ignore-version
+target create $CHIPNAME.cpu rvmax -chain-position $CHIPNAME.cpu
+
+$CHIPNAME.cpu configure -work-area-phys 0x20010000 -work-area-size 0x1000
+
+flash bank $CHIPNAME.flash max32xxx $FLASH_BASE $FLASH_SIZE 0 0 $CHIPNAME.cpu $FLC_BASE $FLASH_SECTOR $FLASH_CLK $FLASH_OPTIONS
+
+$CHIPNAME.cpu configure -event reset-end { 
+    # Set the PC to the load address where the interrupt vector is stored
+    reg pc Reset_Handler
+}

--- a/tcl/target/max78000_riscv.cfg
+++ b/tcl/target/max78000_riscv.cfg
@@ -1,4 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # MAX78000 RISC-V core OpenOCD configuration
+# www.analog.com
 
 # Set the reset pin configuration
 reset_config srst_only
@@ -25,7 +27,7 @@ $CHIPNAME.cpu configure -work-area-phys 0x20010000 -work-area-size 0x1000
 
 flash bank $CHIPNAME.flash max32xxx $FLASH_BASE $FLASH_SIZE 0 0 $CHIPNAME.cpu $FLC_BASE $FLASH_SECTOR $FLASH_CLK $FLASH_OPTIONS
 
-$CHIPNAME.cpu configure -event reset-end { 
+$CHIPNAME.cpu configure -event reset-end {
     # Set the PC to the load address where the interrupt vector is stored
     reg pc Reset_Handler
 }

--- a/tcl/target/max78002_riscv.cfg
+++ b/tcl/target/max78002_riscv.cfg
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# MAX78002 RISC-V core OpenOCD configuration
+# www.analog.com
+
+# Set the reset pin configuration
+reset_config srst_only
+
+# set reset delay so ARM core can re-enable RISCV debugger pins
+adapter srst delay 100
+
+adapter speed 4000
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x280000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 100
+set FLASH_OPTIONS 0x01
+
+set CHIPNAME max32xxx_riscv
+
+jtag newtap $CHIPNAME cpu -irlen 4 -irmask 0xf -ircapture 0x5 -expected-id 0x16210197 -ignore-version
+target create $CHIPNAME.cpu rvmax -chain-position $CHIPNAME.cpu
+
+$CHIPNAME.cpu configure -work-area-phys 0x20010000 -work-area-size 0x1000
+
+flash bank $CHIPNAME.flash max32xxx $FLASH_BASE $FLASH_SIZE 0 0 $CHIPNAME.cpu $FLC_BASE $FLASH_SECTOR $FLASH_CLK $FLASH_OPTIONS
+
+$CHIPNAME.cpu configure -event reset-end {
+    # Set the PC to the load address where the interrupt vector is stored
+    reg pc Reset_Handler
+}


### PR DESCRIPTION
This PR adds RISC-V config files for the:
* MAX32680
* MAX32690
* MAX78000
* MAX78002

It also changes the `reset-end` event for the MAX32655 to set the program counter to `Reset_Handler` instead of the hard-coded `0x10004000` address.